### PR TITLE
Add an NFData instance to StateCode

### DIFF
--- a/src/Data/StateCodes/ISO31662US.hs
+++ b/src/Data/StateCodes/ISO31662US.hs
@@ -22,6 +22,7 @@ module Data.StateCodes.ISO31662US
   ) where
 
 import           Control.Arrow         ((&&&))
+import           Control.DeepSeq       (NFData(..))
 import           Data.Aeson
 import           Data.Text             (Text)
 import qualified Data.Text             as T
@@ -397,3 +398,8 @@ instance FromJSON StateCode where
 
 instance RenderMessage master StateCode where
   renderMessage _ _ = toName
+
+
+-- | Allow the deep evaluation of StateCode with `deepseq`
+instance NFData StateCode where
+  rnf a = a `seq` ()

--- a/state-codes.cabal
+++ b/state-codes.cabal
@@ -31,6 +31,7 @@ library
       base                 >= 4.7  && < 5
     , text
     , aeson
+    , deepseq
     , shakespeare
   if flag(dev)
     ghc-options:       -Wall -Werror


### PR DESCRIPTION
We encountered a use case for `deepseq`, but it requires every part of a data structure to implement `NFData`.

Implementing `NFData` as needed results in a warning about orphan instances, which is undesirable. Instead, we would like the `state-codes` package to provide the `NFData` instance.
